### PR TITLE
shift attributes to flake.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,19 +1,16 @@
-{ nixpkgs
-, system
+{ system
 , inputs
-,
+, buildDotnetModule
+, dotnet-sdk
+, dotnet-runtime
+, version
+, port
 }:
-with nixpkgs; let
+let
   # started configuration attributes for dotnet projects
   pname = "rplwork_client";
-  version = "1.1.0";
   projectFile = "rplwork_client.csproj";
   src = ./rplwork_client;
-  port = "5000";
-
-  # controls what sdk the project is built with and what runtime it is run in
-  dotnet-sdk = dotnetCorePackages.dotnet_9.sdk;
-  dotnet-runtime = dotnetCorePackages.dotnet_9.aspnetcore;
 
   # helpful tool that will handle nuget dependencies
   nuget-packageslock2nix = inputs.nuget-packageslock2nix;

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,11 @@
 
       port = "5000";
 
+      # define which sdk/runtime used by the application
+      # each represents an attribute path in nixpkgs
+      dotnet-sdk = [ "dotnetCorePackages" "dotnet_9" "sdk" ];
+      dotnet-runtime = [ "dotnetCorePackages" "dotnet_9" "aspnetcore" ];
+
       # System types to support.
       supportedSystems = [
         "x86_64-linux"
@@ -41,11 +46,6 @@
         "aarch64-linux"
         "aarch64-darwin"
       ];
-
-      # define which sdk/runtime used by the application
-      # each represents an attribute path in nixpkgs
-      dotnet-sdk = [ "dotnetCorePackages" "dotnet_9" "sdk" ];
-      dotnet-runtime = [ "dotnetCorePackages" "dotnet_9" "aspnetcore" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
             };
             default = self.packages.${system}.rplwork-client;
             rplwork-image = import ./pkgs/rplwork-client-image.nix {
-              nixpkgs = pkgs;
+              inherit (pkgs) dockerTools buildEnv runtimeShell lib;
               rplwork-client = self.packages.${system}.default;
             };
           }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
         "aarch64-darwin"
       ];
 
+      dotnet-sdk = [ "dotnetCorePackages" "sdk_9_0_1xx" ];
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
@@ -75,12 +76,19 @@
         }
       );
 
-      devShells = forAllSystems (system: {
-        default = import ./shell.nix {
-          inherit system inputs;
-          nixpkgs = nixpkgsFor.${system};
-        };
-      });
+      devShells = forAllSystems
+        (system:
+          let
+            pkgs = nixpkgsFor.${system};
+          in
+          {
+            default = import ./shell.nix
+              {
+                inherit system inputs;
+                inherit (pkgs) mkShell;
+                dotnet-sdk = pkgs.lib.attrsets.getAttrFromPath dotnet-sdk pkgs;
+              };
+          });
     } // {
       # nixosModules.default = nixCats.nixosModules.default;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,10 @@
       lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
 
       # Generate a user-friendly version number.
-      version = builtins.substring 0 8 lastModifiedDate;
+      revision = builtins.substring 0 8 lastModifiedDate;
+      version = builtins.concatStringsSep "." [ "1" "1" revision ];
+
+      port = "5000";
 
       # System types to support.
       supportedSystems = [
@@ -39,7 +42,11 @@
         "aarch64-darwin"
       ];
 
-      dotnet-sdk = [ "dotnetCorePackages" "sdk_9_0_1xx" ];
+      # define which sdk/runtime used by the application
+      # each represents an attribute path in nixpkgs
+      dotnet-sdk = [ "dotnetCorePackages" "dotnet_9" "sdk" ];
+      dotnet-runtime = [ "dotnetCorePackages" "dotnet_9" "aspnetcore" ];
+
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
@@ -62,19 +69,26 @@
       # The default package for 'nix build'. This makes sense if the
       # flake provides only one package or there is a clear "main"
       # package.
-      packages = forAllSystems (
-        system: {
-          rplwork-client = import ./default.nix {
-            inherit system inputs;
-            nixpkgs = nixpkgsFor.${system};
-          };
-          default = self.packages.${system}.rplwork-client;
-          rplwork-image = import ./pkgs/rplwork-client-image.nix {
-            nixpkgs = nixpkgsFor.${system};
-            rplwork-client = self.packages.${system}.default;
-          };
-        }
-      );
+      packages = forAllSystems
+        (system:
+          let
+            pkgs = nixpkgsFor.${system};
+          in
+          {
+            rplwork-client = import ./default.nix {
+              inherit system inputs version port;
+              inherit (pkgs) buildDotnetModule;
+              # resolve the attribute path to the actual derivation
+              dotnet-sdk = pkgs.lib.attrsets.getAttrFromPath dotnet-sdk pkgs;
+              dotnet-runtime = pkgs.lib.attrsets.getAttrFromPath dotnet-runtime pkgs;
+            };
+            default = self.packages.${system}.rplwork-client;
+            rplwork-image = import ./pkgs/rplwork-client-image.nix {
+              nixpkgs = pkgs;
+              rplwork-client = self.packages.${system}.default;
+            };
+          }
+        );
 
       devShells = forAllSystems
         (system:

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,8 @@
 
       # define which sdk/runtime used by the application
       # each represents an attribute path in nixpkgs
-      dotnet-sdk = [ "dotnetCorePackages" "dotnet_9" "sdk" ];
-      dotnet-runtime = [ "dotnetCorePackages" "dotnet_9" "aspnetcore" ];
+      dotnet-sdk = [ "dotnetCorePackages" "dotnet_10" "sdk" ];
+      dotnet-runtime = [ "dotnetCorePackages" "dotnet_10" "aspnetcore" ];
 
       # System types to support.
       supportedSystems = [

--- a/pkgs/rplwork-client-image.nix
+++ b/pkgs/rplwork-client-image.nix
@@ -1,7 +1,10 @@
 { rplwork-client
-, nixpkgs
-,
-}: with nixpkgs; let
+, dockerTools
+, buildEnv
+, runtimeShell
+, lib
+}:
+let
   image = dockerTools.buildImage {
     name = lib.strings.concatStrings [ "rynplynch/" rplwork-client.pname ];
     tag = rplwork-client.version;

--- a/rplwork_client/packages.lock.json
+++ b/rplwork_client/packages.lock.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    "net9.0": {}
+    "net10.0": {}
   }
 }

--- a/rplwork_client/rplwork_client.csproj
+++ b/rplwork_client/rplwork_client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,8 @@
-{ nixpkgs ? import <nixpkgs> { }
-, system
+{ system
 , inputs
-,
+, dotnet-sdk
+, mkShell
 }:
-with nixpkgs;
 let
   ryanl-nvim = inputs.ryanl-nvim.packages.${system}.default;
   inherit (ryanl-nvim) utils;
@@ -31,13 +30,14 @@ in
 mkShell {
   buildInputs = [
     customNixCats
+    dotnet-sdk
   ];
 
   shellHook = ''
     # append global dotnet tools to PATH
     export PATH="$PATH:$HOME/.dotnet/tools"
     # global tools use this environment variable to locate dotnet runtime
-    export DOTNET_ROOT=${pkgs.dotnetCorePackages.sdk_8_0_1xx}/share/dotnet/
+    export DOTNET_ROOT=${dotnet-sdk}/share/dotnet/
   '';
 }
 


### PR DESCRIPTION
having our attributes in flake.nix makes it easier to maintain. All our packages/shell's can share these. For instance updating from dotnet 9 -> 10 was made easy!
